### PR TITLE
Minor modification to the solver plugin

### DIFF
--- a/CaeUnsUMCPSEG.cxx
+++ b/CaeUnsUMCPSEG.cxx
@@ -17,6 +17,7 @@
 #include "apiPWP.h"
 #include "runtimeWrite.h"
 #include "pwpPlatform.h"
+#include <iostream>
 
 #include "CaePlugin.h"
 #include "CaeUnsGridModel.h"
@@ -44,32 +45,34 @@ matIdChar(const MaterialId matId)
     return (matId < 0 || matId > 35) ? '?' : idMap[matId];
 }
 
-
-static MaterialId
-maxMatId(const MaterialId id1, const MaterialId id2)
-{
+//
+// >JK: 1/2018: Old function, no longer needed
+// static MaterialId
+// maxMatId(const MaterialId id1, const MaterialId id2)
+// {
     // Ignore zero mat id if a non-zero value is present
-    MaterialId ret;
-    if ((id1 > 0) && (id2 > 0)) {
-        ret = std::max(id1, id2); // both are >0, max wins.
-    }
-    else if (id1 > 0) {
-        ret = id1;
-    }
-    else if (id2 > 0) {
-        ret = id2;
-    }
-    else if (0 == id1) {
-        ret = id1;
-    }
-    else if (0 == id2) {
-        ret = id2;
-    }
-    else {
-        ret = MatUndefined; // not good?
-    }
-    return ret;
-}
+
+//    MaterialId ret;
+//    if ((id1 > 0) && (id2 > 0)) {
+//        ret = std::max(id1, id2); // both are >0, max wins.
+//    }
+//    else if (id1 > 0) {
+//        ret = id1;
+//    }
+//    else if (id2 > 0) {
+//        ret = id2;
+//    }
+//    else if (0 == id1) {
+//        ret = id1;
+//    }
+//    else if (0 == id2) {
+//        ret = id2;
+//    }
+//    else {
+//        ret = MatUndefined; // not good?
+//    }
+//    return ret;
+// }
 
 
 template<typename T>
@@ -647,9 +650,9 @@ CaeUnsUMCPSEG::getIntorEdgeMatAndZone(const PWGM_FACESTREAM_DATA &data,
             // if material is different, return highest ids
             // and zone corresponding to higher material id
             if (nborMatId != matId) {
-                matId = maxMatId(nborMatId, matId);
+                matId = std::max(nborMatId, matId);
                 if (matId == nborMatId) {
-                    zoneId = nborZoneId
+                    zoneId = nborZoneId;
                 }
             }
             // if material is the same and zone is different,

--- a/CaeUnsUMCPSEG.h
+++ b/CaeUnsUMCPSEG.h
@@ -81,11 +81,12 @@ public:
             id_ = id; // capture first positive, nonzero id
             hadConflict_ = true;
         }
-        else if (id < id_) {
+        else if (id > id_) {
             id_ = id; // cature the lowest id
             hadConflict_ = true;
         }
-        else if (id > id_) {
+// >JK: 1/2018 Changing the logic here to have the highest MatId have the ownership
+        else if (id < id_) {
             hadConflict_ = true;
         }
         // else id == id_ // a NOP


### PR DESCRIPTION
At geometric boundaries, the material with a higher ID number should be given priority (not the lower ID number) for node ownership. Secondly, at boundaries where two materials are meeting, and the materials are the same while the zone is different, node ownership is given to the higher zone. Version naming of output file changed from 4 to 5 for consistency on CPSEG side.